### PR TITLE
Skip empty lines when parsing properties to json

### DIFF
--- a/macros/shared/src/main/scala/profig/ProfigLookupPath.scala
+++ b/macros/shared/src/main/scala/profig/ProfigLookupPath.scala
@@ -96,7 +96,7 @@ object ProfigLookupPath {
   def propertiesString2Json(string: String): Json = {
     val properties = new Properties
     var continuing: Option[(String, String)] = None
-    string.split('\n').filter(!_.isEmpty).foreach {
+    string.split('\n').filter(_.nonEmpty).foreach {
       case line if line.startsWith("#") || line.startsWith("!") =>   // Ignore
       case line => {
         continuing match {

--- a/macros/shared/src/main/scala/profig/ProfigLookupPath.scala
+++ b/macros/shared/src/main/scala/profig/ProfigLookupPath.scala
@@ -96,7 +96,7 @@ object ProfigLookupPath {
   def propertiesString2Json(string: String): Json = {
     val properties = new Properties
     var continuing: Option[(String, String)] = None
-    string.split('\n').foreach {
+    string.split('\n').filter(!_.isEmpty).foreach {
       case line if line.startsWith("#") || line.startsWith("!") =>   // Ignore
       case line => {
         continuing match {


### PR DESCRIPTION
Without this, I get a scala.MatchError if my properties file has any blank lines.