### PR TITLE
Make EqualsProperty and ColonProperty regexes lazy

### DIFF
--- a/macros/shared/src/main/scala/profig/ProfigLookupPath.scala
+++ b/macros/shared/src/main/scala/profig/ProfigLookupPath.scala
@@ -90,8 +90,8 @@ object ProfigLookupPath {
     case Right(value) => value
   }
 
-  private val EqualsProperty = """(.+)=(.+)""".r
-  private val ColonProperty = """(.+)[:](.+)""".r
+  private val EqualsProperty = """(.+?)=(.+)""".r
+  private val ColonProperty = """(.+?)[:](.+)""".r
 
   def propertiesString2Json(string: String): Json = {
     val properties = new Properties


### PR DESCRIPTION
Those regexes are used to split property lines into key and value.
But if the value of a property contains an equals sign (=) or a
colon (:) then the regexes fail to split the property lines
correctly. Because they are greedy and try to match as much as
possible. This fix makes them lazy, so they will split at the
first occurrence of (=) or (:).